### PR TITLE
Fixed paths of conversion header file in TMP117 and ADXL375

### DIFF
--- a/device/peripherals/ADXL375/ADXL375.h
+++ b/device/peripherals/ADXL375/ADXL375.h
@@ -9,16 +9,16 @@
 
 #define ADXL375_DATA_STRUCT(variable_name) ADXL375::ADXL375_DATA_T variable_name = {.id = 12000, .x_accel = 0, .y_accel = 0, .z_accel = 0}
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
+#include "common/utils/conversion.h"
 #include "device/I2CDevice.h"
-#include "utils/conversion.h"
-#include "sched/macros.h"
 #include "return.h"
+#include "sched/macros.h"
 
 class ADXL375 : public Device {
-public:
+   public:
     typedef enum {
         xLSBDataReg = 0x32,
         xMSBDataReg = 0x33,
@@ -76,8 +76,7 @@ public:
     static constexpr float ADXL375_GRAVITY = 9.80665F;
 
     explicit ADXL375(I2CDevice &i2c, const uint16_t address = ADXL375_DEV_ADDR_PRIM, const char *name = "ADXl375")
-            : Device(name), m_i2c(&i2c),
-              i2cAddr({.dev_addr = static_cast<uint16_t>(address << 1), .mem_addr = 0, .mem_addr_size = 1}) {}
+        : Device(name), m_i2c(&i2c), i2cAddr({.dev_addr = static_cast<uint16_t>(address << 1), .mem_addr = 0, .mem_addr_size = 1}) {}
 
     RetType init() override {
         RESUME();
@@ -123,7 +122,7 @@ public:
      */
     RetType readXYZ(int16_t *xAxis, int16_t *yAxis, int16_t *zAxis) {
         constexpr float scale = ADXL375_MG2G_MULTIPLIER * ADXL375_GRAVITY;
-        constexpr float bound = 500; // Good chance we're not going past Mach 1.5
+        constexpr float bound = 500;  // Good chance we're not going past Mach 1.5
 
         RESUME();
 
@@ -134,7 +133,7 @@ public:
         *yAxis = static_cast<int16_t>((m_buff[3] << 8) | m_buff[2]) * scale;
         *zAxis = static_cast<int16_t>((m_buff[5] << 8) | m_buff[4]) * scale;
 
-        if ((bound < abs(*xAxis)) || (bound < abs(*yAxis)) || (bound < abs(*zAxis)) ) {
+        if ((bound < abs(*xAxis)) || (bound < abs(*yAxis)) || (bound < abs(*zAxis))) {
             ret = RET_ERROR;
         }
 
@@ -286,7 +285,7 @@ public:
         return ret;
     }
 
-private:
+   private:
     I2CDevice *m_i2c;
     I2CAddr_t i2cAddr;
     uint8_t m_buff[6];
@@ -341,8 +340,6 @@ private:
         RESET();
         return ret;
     }
-
 };
 
-
-#endif //ADXL375_H
+#endif  // ADXL375_H

--- a/device/peripherals/ADXL375/ADXL375.h
+++ b/device/peripherals/ADXL375/ADXL375.h
@@ -12,8 +12,8 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#include "common/utils/conversion.h"
 #include "device/I2CDevice.h"
-#include "utils/conversion.h"
 #include "sched/macros.h"
 #include "return.h"
 

--- a/device/peripherals/TMP117/TMP117.h
+++ b/device/peripherals/TMP117/TMP117.h
@@ -9,10 +9,10 @@
 
 #include <stdint.h>
 
+#include "common/utils/conversion.h"
 #include "device/I2CDevice.h"
 #include "sched/macros.h"
 #include "return.h"
-#include "utils/conversion.h"
 
 #define TMP117_DATA_STRUCT(variable_name) TMP117::TMP117_DATA_T variable_name = {.id = 16001, .temperature = 0}
 

--- a/device/peripherals/TMP117/TMP117.h
+++ b/device/peripherals/TMP117/TMP117.h
@@ -9,15 +9,15 @@
 
 #include <stdint.h>
 
+#include "common/utils/conversion.h"
 #include "device/I2CDevice.h"
-#include "sched/macros.h"
 #include "return.h"
-#include "utils/conversion.h"
+#include "sched/macros.h"
 
 #define TMP117_DATA_STRUCT(variable_name) TMP117::TMP117_DATA_T variable_name = {.id = 16001, .temperature = 0}
 
 class TMP117 : public Device {
-public:
+   public:
     typedef struct {
         const uint16_t id;
         float temperature;
@@ -56,10 +56,7 @@ public:
     constexpr static uint16_t DEVICE_ID_VALUE = 0x0117;
     constexpr static float TMP117_RESOLUTION = 0.0078125f;
 
-
-    explicit TMP117(I2CDevice &i2CDevice, const uint16_t address = TMP_117_DEVICE_ADDR, const char *name = "TMP117") :
-            Device(name), mI2C(&i2CDevice),
-            i2cAddr({.dev_addr = static_cast<uint16_t>(address << 1), .mem_addr = 0, .mem_addr_size = 1}) {}
+    explicit TMP117(I2CDevice &i2CDevice, const uint16_t address = TMP_117_DEVICE_ADDR, const char *name = "TMP117") : Device(name), mI2C(&i2CDevice), i2cAddr({.dev_addr = static_cast<uint16_t>(address << 1), .mem_addr = 0, .mem_addr_size = 1}) {}
 
     /**
      * @brief Initialize the TMP117 sensor
@@ -95,7 +92,6 @@ public:
         return ret;
     }
 
-
     /**
      * @brief Get the data from the TMP117 sensor in Celsius
      *
@@ -115,7 +111,6 @@ public:
         return ret;
     }
 
-
     /**
      * Get the data from the TMP117 sensor in Fahrenheit
      * @param temp[out] - Pointer to the temperature variable in F
@@ -129,11 +124,9 @@ public:
             *temp = celsius_to_fahrenheit(*temp);
         }
 
-
         RESET();
         return ret;
     }
-
 
     /**
      * Get the temperature offset in mC for calibration
@@ -169,7 +162,6 @@ public:
         RESET();
         return ret;
     }
-
 
     /**
      * @brief Gets the limit set for alerts
@@ -247,7 +239,7 @@ public:
         return ret;
     }
 
-private:
+   private:
     I2CDevice *mI2C;
     I2CAddr_t i2cAddr;
     uint8_t tx_buff[2]{};
@@ -307,4 +299,4 @@ private:
     }
 };
 
-#endif //LAUNCH_CORE_TMP117_H
+#endif  // LAUNCH_CORE_TMP117_H


### PR DESCRIPTION
Sorry Aaron my autoformatter moved stuff and I couldn't make it not move stuff :(